### PR TITLE
Fix Image picker on iOS

### DIFF
--- a/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
+++ b/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
@@ -228,6 +228,12 @@ open class TLPhotosPickerViewController: UIViewController {
     
     override open func viewDidLoad() {
         super.viewDidLoad()
+        if let layout = collectionView.collectionViewLayout as? UICollectionViewFlowLayout {
+                layout.minimumInteritemSpacing = 1
+                layout.minimumLineSpacing = 1
+                let width = (collectionView.frame.width - 2) / 3
+                layout.itemSize = CGSize(width: width, height: width)
+        }
         makeUI()
         checkAuthorization()
     }


### PR DESCRIPTION
**Fixed Image Picker Issue in TLPhotoPicker Dependency**
Resolved a critical issue in the TLPhotoPicker dependency used in the `fk-ios-app` repository. The problem involved the image picker, where the middle column of a three-column layout was blank, leaving no images displayed. The issue was identified and fixed, ensuring all three columns display images correctly, improving the overall user experience in the image picker section.

