### PR TITLE
Fix Image picker on iOS

### DIFF
--- a/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
+++ b/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
@@ -228,6 +228,12 @@ open class TLPhotosPickerViewController: UIViewController {
     
     override open func viewDidLoad() {
         super.viewDidLoad()
+        if let layout = collectionView.collectionViewLayout as? UICollectionViewFlowLayout {
+                layout.minimumInteritemSpacing = 1
+                layout.minimumLineSpacing = 1
+                let width = (collectionView.frame.width - 2) / 3
+                layout.itemSize = CGSize(width: width, height: width)
+        }
         makeUI()
         checkAuthorization()
     }

--- a/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
+++ b/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
@@ -231,6 +231,8 @@ open class TLPhotosPickerViewController: UIViewController {
         if let layout = collectionView.collectionViewLayout as? UICollectionViewFlowLayout {
                 layout.minimumInteritemSpacing = 1
                 layout.minimumLineSpacing = 1
+                //Subtracting 2 from the overall width to account for the spacing between items
+                //(1 point on each side) in the 3-column layout.
                 let width = (collectionView.frame.width - 2) / 3
                 layout.itemSize = CGSize(width: width, height: width)
         }


### PR DESCRIPTION
## Fixed Image Picker Issue in TLPhotoPicker Dependency

Resolved a critical issue in the TLPhotoPicker dependency used in the `fk-ios-app` repository. The problem involved the image picker, where the middle column of a three-column layout was blank, leaving no images displayed. The issue was identified and fixed, ensuring all three columns display images correctly, which improves the overall user experience in the image picker section.

### Issue Details
<table>
  <tr>
    <td>
      <strong>Before Fix</strong><br/>
      <img src="https://drive.google.com/uc?export=view&id=1brs_B3NmSFehbY0XYvJOkChQfsx2sU-O" alt="Before Fix" width="300"/>
    </td>
    <td>
      <strong>After Fix</strong><br/>
      <img src="https://drive.google.com/uc?export=view&id=1w1we8zNvLRJNMVaDU5LsI3b6giL1NHOC" alt="After Fix" width="300"/>
    </td>
  </tr>
</table>
